### PR TITLE
Readability | Simplification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.31.0
 psycopg2==2.9.9
-python_dotenv=1.0.0
+python_dotenv==1.0.0

--- a/selectors.py
+++ b/selectors.py
@@ -1,12 +1,11 @@
 from database import cur
 
 
-def get_user(username: str) -> tuple[int, str, str]:
+def get_user(username: str) -> tuple[int, str, str] | None:
     cur.execute(
         f"""
         SELECT * FROM auth_user 
         WHERE username = '{username}'
         """
     )
-    user = cur.fetchone()
-    return user
+    return cur.fetchone()

--- a/validators.py
+++ b/validators.py
@@ -4,20 +4,20 @@ from constants import MIN_PASSWORD_LENGTH, PROHIBITED_PASSWORD_CHARACTERS, MIN_U
 
 def validate_password(password: str) -> None:
     if len(password) < MIN_PASSWORD_LENGTH:
-        raise ValueError(f"Password length must be more than {MIN_PASSWORD_LENGTH} symbols or equal")
+        raise ValueError(f"Password length must be greater than or equal to {MAX_PASSWORD_LENGTH}")
     for character in PROHIBITED_PASSWORD_CHARACTERS:
         if character in password:
             prohibited_characters = ", ".join(PROHIBITED_PASSWORD_CHARACTERS)
             raise ValueError(
-                f"{character} is not allowed in password,"
-                f" there are such prohibited characters: {prohibited_characters}"
+                f"The {character} symbol is hidden in the password, there are all "
+                f"prohibited characters: {prohibited_characters}"
             )
     if len(password) > MAX_PASSWORD_LENGTH:
-        raise ValueError(f"Password length must be less than {MAX_PASSWORD_LENGTH} symbols or equal")
+        raise ValueError(f"Password length must be less than or equal to {MIN_PASSWORD_LENGTH}")
 
 
 def validate_username(username: str) -> None:
     if len(username) < MIN_USERNAME_LENGTH:
-        raise ValueError(f"Username length must be more than {MIN_USERNAME_LENGTH} symbols or equal")
+        raise ValueError(f"Username length must be greater than or equal to {MAX_USERNAME_LENGTH}")
     if len(username) > MAX_USERNAME_LENGTH:
-        raise ValueError(f"Username length must be less than {MAX_USERNAME_LENGTH} symbols or equal")
+        raise ValueError(f"Username length must be less than or equal to {MIN_USERNAME_LENGTH}")


### PR DESCRIPTION
Fixed a bug in the name of the python_dotenv library (Added double equal instead of single), made the description of validator errors more readable. Add missing type hints.